### PR TITLE
Refactor DataFrame Conversion Logic with auto_convert_dataframes Decorator

### DIFF
--- a/src/skpm/base.py
+++ b/src/skpm/base.py
@@ -3,6 +3,7 @@ from pandas import DataFrame
 from sklearn.base import BaseEstimator
 
 from .config import EventLogConfig as elc
+from .utils.helpers import auto_convert_dataframes
 from .utils.validation import ensure_list, validate_columns
 
 
@@ -16,6 +17,7 @@ class BaseProcessEstimator(BaseEstimator):
     For instance, all event logs must have a `case_id` column.
     """
 
+    @auto_convert_dataframes
     def _validate_log(
             self,
             X: DataFrame,
@@ -50,11 +52,6 @@ class BaseProcessEstimator(BaseEstimator):
         ValueError
             If the input is not a DataFrame or if the case ID column is missing.
         """
-        polar_df = False
-        if isinstance(X, pl.DataFrame):  # For Polars DataFrame
-            X = X.to_pandas()
-            polar_df = True
-
         self._validate_params()
 
         # TODO: the validation of a dataframe might be done
@@ -78,16 +75,11 @@ class BaseProcessEstimator(BaseEstimator):
             cast_to_ndarray=cast_to_ndarray,
         )
 
-        # if cols:
         cols = validate_columns(
             input_columns=data.columns,
             required=[elc.case_id] + self.features_,
         )
-        # else:
-        #     cols = data.columns
 
-        if polar_df:  # For Polars DataFrame
-            data = pl.from_pandas(data)
         return data[cols]
 
     def _ensure_case_id(self, columns: list[str]):

--- a/src/skpm/encoding/trace.py
+++ b/src/skpm/encoding/trace.py
@@ -183,9 +183,6 @@ class Aggregation(OneToOneFeatureMixin, TransformerMixin, BaseProcessEstimator):
         elif self.engine == "polars":  # If using Polars DataFrame
             return self._transform_polars(X)
 
-        else:
-            raise ValueError("Invalid engine. Supported engines are 'pandas' and 'polars'.")
-
     def _transform_pandas(self, X):
         """Transforms Pandas DataFrame."""
         group = X.groupby(elc.case_id)
@@ -293,9 +290,6 @@ class WindowAggregation(Aggregation):
 
         elif self.engine == "polars":  # If using Polars DataFrame
             return self._transform_polars(X)
-
-        else:
-            raise ValueError("Invalid engine. Supported engines are 'pandas' and 'polars'.")
 
     def _transform_pandas(self, X):
         """Transforms Pandas DataFrame."""

--- a/src/skpm/utils/helpers.py
+++ b/src/skpm/utils/helpers.py
@@ -1,14 +1,79 @@
+from functools import wraps
+import pandas as pd
 import polars as pl
 
 
 # def flatten_list(l: list):
 #     return [item for sublist in l for item in sublist]
 
+def auto_convert_dataframes(func):
+    """
+    A decorator that automatically converts DataFrame objects to Pandas DataFrame if necessary.
 
+    Args:
+        func (function): The function to be decorated.
+
+    Returns:
+        function: The decorated function.
+
+    """
+    if len(func.__qualname__.split('.')) > 1:  # check if decorator is used on a method function
+        def wrapper(self, df, *args, **kwargs):
+            """
+            Method wrapper function that checks if the input DataFrame is a Polars DataFrame.
+            If it is, it converts it to a pandas DataFrame, executes the function,
+            and converts the result back to a Polars DataFrame if necessary.
+
+            Args:
+                self: class instance
+                df (DataFrame): The input DataFrame.
+                *args: Variable length argument list.
+                **kwargs: Arbitrary keyword arguments.
+
+            Returns:
+                DataFrame: The result DataFrame, possibly converted to Polars format.
+
+            """
+            if isinstance(df, pl.DataFrame):
+                df = df.to_pandas()
+                result = func(self, df, *args, **kwargs)
+                if isinstance(result, pd.DataFrame):
+                    result = pl.from_pandas(result)
+                return result  # returns polars df
+            result = func(self, df, *args, **kwargs)
+            return result
+    else:
+
+        def wrapper(df, *args, **kwargs):
+            """
+            Wrapper function that checks if the input DataFrame is a Polars DataFrame.
+            If it is, it converts it to a pandas DataFrame, executes the function,
+            and converts the result back to a Polars DataFrame if necessary.
+
+            Args:
+                df (DataFrame): The input DataFrame.
+                *args: Variable length argument list.
+                **kwargs: Arbitrary keyword arguments.
+
+            Returns:
+                DataFrame: The result DataFrame, possibly converted to Polars format.
+
+            """
+            if isinstance(df, pl.DataFrame):
+                df = df.to_pandas()
+                result = func(df, *args, **kwargs)
+                if isinstance(result, pd.DataFrame):
+                    result = pl.from_pandas(result)
+                return result  # returns polars df
+            result = func(df, *args, **kwargs)
+            return result
+
+    return wrapper
+
+
+@auto_convert_dataframes
 def infer_column_types(df, int_as_cat=False) -> tuple:
     """Infer column types from a dataframe."""
-    if isinstance(df, pl.DataFrame):  # For Polars DataFrame
-        df = df.to_pandas()
     cat_cols = ["object", "category"]
     if int_as_cat:
         cat_cols.append("int")


### PR DESCRIPTION
This pull request refactors the data frame conversion logic within utility functions that exclusively accept Pandas DataFrames. The conversion logic has been consolidated into the `auto_convert_dataframes` decorator, which resides in the `utils/helpers` file.

Changes Made:
- Introduced the `auto_convert_dataframes` decorator to automate the conversion of DataFrame objects.
- Migrated the DataFrame conversion logic from individual utility functions to the decorator.
- Updated all affected utility functions to utilize the `auto_convert_dataframes` decorator.
