### PR TITLE
Unbiased split 

### DIFF
--- a/src/skpm/event_logs/__init__.py
+++ b/src/skpm/event_logs/__init__.py
@@ -2,9 +2,15 @@ from .bpi import (
     BPI12,
     BPI13ClosedProblems,
     BPI13Incidents,
+    BPI13OpenProblems,
     BPI17,
     BPI19,
-    BPI20,
+    BPI20PrepaidTravelCosts,
+    BPI20TravelPermitData,
+    BPI20RequestForPayment,
+    BPI20DomesticDeclarations,
+    BPI20InternationalDeclarations,
+    Sepsis,
 )
 
 from .parser import read_xes
@@ -13,8 +19,14 @@ __all__ = [
     "BPI12",
     "BPI13ClosedProblems",
     "BPI13Incidents",
+    "BPI13OpenProblems",
     "BPI17",
     "BPI19",
-    "BPI20",
+    "BPI20PrepaidTravelCosts",
+    "BPI20TravelPermitData",
+    "BPI20RequestForPayment",
+    "BPI20DomesticDeclarations",
+    "BPI20InternationalDeclarations",
+    "Sepsis",
     "read_xes",
 ]

--- a/src/skpm/event_logs/base.py
+++ b/src/skpm/event_logs/base.py
@@ -45,6 +45,8 @@ class TUEventLog(BasePreprocessing):
     file_name: str = None
     meta_data: str = None  # TODO: download DATA.xml from the 4TU repository
 
+    _unbiased_split_params: dict = None
+
     def __init__(
         self,
         root_folder: str = "./data",
@@ -100,6 +102,15 @@ class TUEventLog(BasePreprocessing):
     @file_path.setter
     def file_path(self, value):
         self._file_path = value
+
+    @property
+    def unbiased_split_params(self) -> dict:
+        """
+        dict: Parameters for the unbiased split of the event log.
+        """
+        if self._unbiased_split_params is None:
+            raise ValueError("Unbiased split parameters not supported.")
+        return self._unbiased_split_params
 
     def __len__(self):
         """

--- a/src/skpm/event_logs/base.py
+++ b/src/skpm/event_logs/base.py
@@ -158,17 +158,10 @@ class TUEventLog(BasePreprocessing):
 
         elif self.file_path.endswith(elc.default_file_format):
             log = pd.read_parquet(self.file_path)
+        else:
+            raise ValueError(f"File format not implemented.")
 
-        # log = self._base_preprocess(log)
         return log
-
-        # Ideally we want to standardize the train/test sets
-        # see https://github.com/hansweytjens/predictive-process-monitoring-benchmarks
-        # train, test = self.split_log(log)
-        # train.to_parquet(self.train_file, index=False)
-        # test.to_parquet(self.test_file, index=False)
-
-        # return train if self.train else test
 
     def __repr__(self) -> str:
         """

--- a/src/skpm/event_logs/bpi.py
+++ b/src/skpm/event_logs/bpi.py
@@ -33,6 +33,13 @@ class BPI12(TUEventLog):
     md5: str = "74c7ba9aba85bfcb181a22c9d565e5b5"
     file_name: str = "BPI_Challenge_2012.xes.gz"
 
+    unbiased_split_params = {    
+        "test_len": .2,
+        "start_date": None ,
+        "end_date": "2012-02",
+        "max_days": 32.28,
+    }
+
 
 class BPI13ClosedProblems(TUEventLog):
     """

--- a/src/skpm/event_logs/bpi.py
+++ b/src/skpm/event_logs/bpi.py
@@ -1,5 +1,4 @@
-from .base import TUEventLog
-
+from skpm.event_logs.base import TUEventLog
 
 class BPI12(TUEventLog):
     """BPI Challenge 2012 event log.
@@ -33,13 +32,11 @@ class BPI12(TUEventLog):
     md5: str = "74c7ba9aba85bfcb181a22c9d565e5b5"
     file_name: str = "BPI_Challenge_2012.xes.gz"
 
-    unbiased_split_params = {    
-        "test_len": .2,
+    _unbiased_split_params: dict = {    
         "start_date": None ,
         "end_date": "2012-02",
         "max_days": 32.28,
     }
-
 
 class BPI13ClosedProblems(TUEventLog):
     """
@@ -72,7 +69,6 @@ class BPI13ClosedProblems(TUEventLog):
     md5: str = "4f9c35942f42cb90d911ee4936bbad87"
     file_name: str = "BPI_Challenge_2013_closed_problems.xes.gz"
 
-
 class BPI13Incidents(TUEventLog):
     """
     BPI Challenge 2013 Incidents.
@@ -103,7 +99,6 @@ class BPI13Incidents(TUEventLog):
     )
     md5: str = "d4809bd55e3e1c15b017ab4e58228297"
     file_name: str = "BPI_Challenge_2013_incidents.xes.gz"
-
 
 class BPI13OpenProblems(TUEventLog):
     """
@@ -136,12 +131,9 @@ class BPI13OpenProblems(TUEventLog):
     md5: str = "9663e544a2292edf1fe369747736e7b4"
     file_name: str = "BPI_Challenge_2013_open_problems.xes.gz"
 
-
 class BPI17(TUEventLog):
     """
     BPI Challenge 2017.
-
-
 
     DOI: 10.4121/uuid:d444d7f1-f81b-45c5-9a1a-0f4d1c1cee7e
 
@@ -181,7 +173,12 @@ class BPI17(TUEventLog):
     )
     md5: str = "10b37a2f78e870d78406198403ff13d2"
     file_name: str = "BPI Challenge 2017.xes.gz"
-
+    
+    _unbiased_split_params: dict = {
+        "start_date": None ,
+        "end_date": "2017-01",
+        "max_days": 47.81,
+    }
 
 class BPI19(TUEventLog):
     """
@@ -214,83 +211,70 @@ class BPI19(TUEventLog):
     md5: str = "4eb909242351193a61e1c15b9c3cc814"
     file_name: str = "BPI_Challenge_2019.xes"
 
-
-class BPI20(TUEventLog):
-    """
-    BPI Challenge 2020.
-
-    DOI: 10.4121/uuid:62b0313f-3bde-447f-a4ce-f28aa06f49b2
-
-    The BPI Challenge 2020 focused on analyzing event data related to business processes in various domains.
-    This class provides access to different versions of the BPI Challenge 2020 event log.
-
-    Parameters
-    ----------
-    version : str, optional
-        The version of the event log to use. Available versions are "permit", "request", "domestic", "prepaid", and "international". Defaults to "permit".
-    root_folder : str, optional
-        Path where the event log will be stored. Defaults to "./data".
-    save_as_pandas : bool, optional
-        Whether to save the event log as a pandas parquet file. Defaults to True.
-    train_set : bool, optional
-        Whether to use the train set or the test set. If True, use the train set. If False, use the test set. Defaults to True.
-    file_path : str, optional
-        Path to the file containing the event log. If provided, the event log will be loaded from this file. Defaults to None.
-
-    Notes
-    -----
-    The BPI Challenge 2020 event log is available in multiple versions corresponding to different types of processes (permit, request, domestic, prepaid, international).
-    Each version has its own URL, MD5 hash, and file name.
-
-    Raises
-    ------
-    NotImplementedError
-        This class does not support direct downloading of the event log from 4TU. Manual download is required.
-    ValueError
-        If an unsupported version is specified.
-
-    Examples
-    --------
-    >>> bpi_20_permit = BPI20(version="permit")
-    >>> bpi_20_permit.download()  # Manually download the event log
-    >>> event_log = bpi_20_permit.log  # Access the event log DataFrame
-    """
-
-    versions = ("permit", "request", "domestic", "prepaid", "international")
-    urls: dict = {
-        "permit": "url1",
-        "request": "url2",
-        "domestic": "url3",
-        "prepaid": "url4",
-        "international": "url5",
-    }
-    md5s: dict = {
-        "permit": "md51",
-        "request": "md52",
-        "domestic": "md53",
-        "prepaid": "md54",
-        "international": "md55",
-    }
-    file_names: dict = {
-        "permit": "BPI_Challenge_2020_permit.xes.gz",
-        "request": "BPI_Challenge_2020_request.xes.gz",
-        "domestic": "BPI_Challenge_2020_domestic.xes.gz",
-        "prepaid": "BPI_Challenge_2020_prepaid.xes.gz",
-        "international": "BPI_Challenge_2020_international.xes.gz",
+    _unbiased_split_params: dict = {
+        "start_date": "2018-01",
+        "end_date": "2019-02",
+        "max_days": 143.33,
     }
 
-    def __init__(
-        self,
-        version: str = "permit",
-        root_folder: str = "./data",
-        save_as_pandas: bool = True,
-        train_set: bool = True,
-        file_path: str = None,
-    ) -> None:
-        raise NotImplementedError("TODO: download from 4TU")
+class BPI20PrepaidTravelCosts(TUEventLog):
+    
+    url: str = (
+        "https://data.4tu.nl/file/fb84cf2d-166f-4de2-87be-62ee317077e5/612068f6-14d0-4a82-b118-1b51db52e73a"
+    )
+    md5: str = "b6ab8ee749e2954f09a4fef030960598"
+    file_name: str = "PrepaidTravelCost.xes.gz"
 
-        if version not in self.versions:
-            raise ValueError(f"Version {version} not in {self.versions}")
-        # TODO
+    _unbiased_split_params: dict = {
+        "start_date": None ,
+        "end_date": "2019-01",
+        "max_days": 114.26,
+    }
 
-        super().__init__(root_folder, save_as_pandas, train_set, file_path)
+class BPI20TravelPermitData(TUEventLog):
+    url: str = (
+        "https://data.4tu.nl/file/db35afac-2133-40f3-a565-2dc77a9329a3/12b48cc1-18a8-4089-ae01-7078fc5e8f90"
+    )
+    md5: str = "b6e9ff00d946f6ad4c91eb6fb550aee4"
+    file_name: str = "PermitLog.xes.gz"
+
+    _unbiased_split_params: dict = {
+        "start_date": None ,
+        "end_date": "2019-10",
+        "max_days": 258.81,
+    }
+
+class BPI20RequestForPayment(TUEventLog):
+    url: str = (
+        "https://data.4tu.nl/file/a6f651a7-5ce0-4bc6-8be1-a7747effa1cc/7b1f2e56-e4a8-43ee-9a09-6e64f45a1a98"
+    )
+    md5 : str = "2eb4dd20e70b8de4e32cc3c239bde7f2"
+    file_name: str = "RequestForPayment.xes.gz"
+    
+    _unbiased_split_params: dict = {
+        "start_date": None ,
+        "end_date": "2018-12",
+        "max_days": 28.86,
+    }
+
+class BPI20DomesticDeclarations(TUEventLog):
+    url: str = (
+        "https://data.4tu.nl/file/6a0a26d2-82d0-4018-b1cd-89afb0e8627f/6eeb0328-f991-48c7-95f2-35033504036e"
+    )
+    md5: str = "6a78c39491498363ce4788e0e8ca75ef"
+    file_name: str = "DomesticDeclarations.xes.gz"
+
+class BPI20InternationalDeclarations(TUEventLog):
+    url: str = (
+        "https://data.4tu.nl/file/91fd1fa8-4df4-4b1a-9a3f-0116c412378f/d45ee7dc-952c-4885-b950-4579a91ef426"
+    )
+    md5: str = "1ec65e046f70bb399cc6d2c154cd615a"
+    file_name: str = "InternationalDeclarations.xes.gz"
+
+class Sepsis(TUEventLog):
+    url: str = (
+        "https://data.4tu.nl/file/33632f3c-5c48-40cf-8d8f-2db57f5a6ce7/643dccf2-985a-459e-835c-a82bce1c0339"
+    )
+    
+    md5: str = "b5671166ac71eb20680d3c74616c43d2"
+    file_name: str = "Sepsis Cases - Event Log.xes.gz"

--- a/src/skpm/event_logs/split.py
+++ b/src/skpm/event_logs/split.py
@@ -18,7 +18,7 @@ def start_from_date(dataset, start_date):
         dataset.groupby("case:concept:name")["time:timestamp"].min().reset_index()
     )
     case_starts_df["date"] = case_starts_df["time:timestamp"].dt.to_period("M")
-    cases_after = case_starts_df[case_starts_df["date"].astype("str") >= start_date][
+    cases_after = case_starts_df[case_starts_df["date"].astype("str") >= pd.Period(start_date)][
         "case:concept:name"
     ].values
     dataset = dataset[dataset["case:concept:name"].isin(cases_after)]
@@ -40,7 +40,7 @@ def end_before_date(dataset, end_date):
         dataset.groupby("case:concept:name")["time:timestamp"].max().reset_index()
     )
     case_stops_df["date"] = case_stops_df["time:timestamp"].dt.to_period("M")
-    cases_before = case_stops_df[case_stops_df["date"].astype("str") <= end_date][
+    cases_before = case_stops_df[case_stops_df["date"] <= pd.Period(end_date)][
         "case:concept:name"
     ].values
     dataset = dataset[dataset["case:concept:name"].isin(cases_before)]
@@ -87,7 +87,7 @@ def limited_duration(dataset, max_duration):
     return dataset, latest_start
 
 
-def trainTestSplit(df, test_len, latest_start, targets):
+def trainTestSplit(dataset, test_len, start_date,end_date, max_days):
     """
     splits the dataset in train and test set, applying strict temporal splitting and
     debiasing the test set
@@ -99,10 +99,20 @@ def trainTestSplit(df, test_len, latest_start, targets):
         df_train: pandas DataFrame
         df_test: pandas DataFrame
     """
+    dataset["time:timestamp"] = pd.to_datetime(dataset["time:timestamp"], utc=True)
+
+    if start_date:
+        dataset = start_from_date(dataset, start_date)
+    if end_date:
+        dataset = end_before_date(dataset, end_date)
+    
+    dataset.drop_duplicates(inplace=True)
+    dataset, latest_start = limited_duration(dataset, max_days)
+    
     # preliminaries
-    case_starts_df = df.groupby("case:concept:name")["time:timestamp"].min()
+    case_starts_df = dataset.groupby("case:concept:name")["time:timestamp"].min()
     case_nr_list_start = case_starts_df.sort_values().index.array
-    case_stops_df = df.groupby("case:concept:name")["time:timestamp"].max().to_frame()
+    case_stops_df = dataset.groupby("case:concept:name")["time:timestamp"].max().to_frame()
 
     ### TEST SET ###
     first_test_case_nr = int(len(case_nr_list_start) * (1 - test_len))
@@ -111,219 +121,16 @@ def trainTestSplit(df, test_len, latest_start, targets):
     test_case_nrs = case_stops_df[
         case_stops_df["time:timestamp"].values >= first_test_start_time
     ].index.array
-    df_test_all = df[df["case:concept:name"].isin(test_case_nrs)].reset_index(drop=True)
+    df_test_all = dataset[dataset["case:concept:name"].isin(test_case_nrs)].reset_index(drop=True)
 
     # drop prefixes in test set that are past latest_start
     df_test = df_test_all[df_test_all["time:timestamp"] <= latest_start]
-
-    # convert targets into np.NAN for those prefixes that end before the separation time (beginning of test set)
-    df_test.loc[df_test["time:timestamp"].values < first_test_start_time, targets] = (
-        np.nan
-    )
 
     #### TRAINING SET ###
     train_case_nrs = case_stops_df[
         case_stops_df["time:timestamp"].values < first_test_start_time
     ].index.array  # added values
-    df_train = df[df["case:concept:name"].isin(train_case_nrs)].reset_index(drop=True)
+    df_train = dataset[dataset["case:concept:name"].isin(train_case_nrs)].reset_index(drop=True)
 
     return df_train, df_test
-
-
-def createClassificationTargets(df, col, keywords_dict):
-    # compute target values for classification
-    def tv(grp):
-        # compute target value (True if one event in group is in keywords)
-        for target, keywords in keywords_dict.items():
-            grp[target] = True in [x in grp[col].values for x in keywords]
-        return grp
-
-    df = df.groupby("case:concept:name").apply(tv)
-    return df
-
-
-def remainTimeOrClassifBenchmark(
-    dataset,
-    path,
-    file_name,
-    start_date,
-    end_date,
-    max_days,
-    test_len_share,
-    output_type="xes",
-    keywords_dict=None,
-):
-    """
-    Creates benchmark training and test sets for remaining time and classification problems
-
-    Args:
-        dataset: pandas DataFrame
-        path: string: output file path
-        file_name: string: output file name
-        start_date: string "MM-YYYY": dataset starts here after removing outliers
-        end_date: string "MM-YYYY": dataset stops here after removing outliers
-        max_days: float
-        test_len_share: float: share of cases belonging in test set
-        output_type: string: "xes", "pickle" or "csv"
-    Returns:
-        two files ('_train' and '_test')
-    """
-
-    # compute the target
-    dataset["time:timestamp"] = pd.to_datetime(dataset["time:timestamp"], utc=True)
-    dataset["remain_time"] = (
-        dataset.groupby("case:concept:name")["time:timestamp"]
-        .apply(lambda x: x.max() - x)
-        .values
-    )
-    dataset["remain_time"] = dataset["remain_time"].dt.total_seconds() / (
-        24 * 60 * 60
-    )  # convert to float days
-
-    # remove chronological outliers and duplicates
-    if start_date:
-        dataset = start_from_date(dataset, start_date)
-    if end_date:
-        dataset = end_before_date(dataset, end_date)
-    dataset.drop_duplicates(inplace=True)
-
-    # drop longest cases and debiasing end of dataset
-    dataset_short, latest_start = limited_duration(dataset, max_days)
-
-    targets = "remain_time"
-    # create targets for classification
-    if keywords_dict:
-        dataset_short = createClassificationTargets(
-            dataset_short, "classif_target", keywords_dict
-        )
-        dataset_short.drop(columns=["classif_target"], inplace=True)
-        targets = list(keywords_dict.keys()) + ["remain_time"]
-
-    # Split dataset in train and test set, applying strict temporal splitting and debiasing the test set
-    dataset_train, dataset_test = trainTestSplit(
-        dataset_short,
-        test_len=test_len_share,
-        latest_start=latest_start,
-        targets=targets,
-    )
-
-    # record outputs
-    if output_type == "xes":
-        log_train = converter.apply(
-            dataset_train, variant=converter.Variants.TO_EVENT_LOG
-        )
-        print("dataset_train converted to logs")
-        xes_exporter.apply(log_train, path + "/" + file_name + "_train.xes")
-        print("dataset_train exported as xes")
-        log_test = converter.apply(
-            dataset_test, variant=converter.Variants.TO_EVENT_LOG
-        )
-        print("dataset_test converted to logs")
-        xes_exporter.apply(log_test, path + "/" + file_name + "_test.xes")
-        print("dataset_test exported as xes")
-    elif output_type == "pickle":
-        dataset_train.to_pickle(path + "/" + file_name + "_train.pkl")
-        dataset_test.to_pickle(path + "/" + file_name + "_test.pkl")
-    elif output_type == "csv":
-        dataset_train.to_csv(path + "/" + file_name + "_train.pkl")
-        dataset_test.to_csv(path + "/" + file_name + "_test.pkl")
-    else:
-        print("output type unknown. Should be 'xes', 'pickle' or 'csv'")
-
-
-def unbiased(
-    dataset,
-    path,
-    file_name,
-    start_date,
-    end_date,
-    max_days,
-    test_len_share,
-    output_type="xes",
-    event_col="activity",
-):
-    """
-    Creates benchmark training and test sets for next event problems
-
-    Args:
-        dataset: pandas DataFrame
-        path: string: output file path
-        file_name: string: output file name
-        start_date: string "MM-YYYY": dataset starts here after removing outliers
-        end_date: string "MM-YYYY": dataset stops here after removing outliers
-        max_days: float
-        test_len_share: float: share of cases belonging in test set
-        output_type: string: "xes", "pickle" or "csv"
-        event_col: string: column containing the event names
-    Returns:
-        two files ('_train' and '_test')
-    """
-
-    # remove chronological outliers and duplicates
-    dataset["time:timestamp"] = pd.to_datetime(dataset["time:timestamp"], utc=True)
-    if start_date:
-        dataset = start_from_date(dataset, start_date)
-    if end_date:
-        dataset = end_before_date(dataset, end_date)
-    dataset.drop_duplicates(inplace=True)
-
-    # drop longest cases and debiasing end of dataset
-    dataset_short, latest_start = limited_duration(dataset, max_days)
-
-    # preliminaries
-    case_stops_df = dataset.groupby("case:concept:name")["time:timestamp"].max()
-
-    ### TRAINING AND TEST SET ###
-    sorted_timestamps = np.sort(dataset["time:timestamp"].values)
-    separation_time = sorted_timestamps[
-        int(len(sorted_timestamps) * (1 - test_len_share))
-    ]
-    print(separation_time)
-
-    # train_case_nrs = case_stops_df[case_stops_df.values <= separation_time].index.array
-    dataset_train = dataset[
-        dataset["time:timestamp"] <= pd.to_datetime(separation_time, utc=True)
-    ].reset_index(drop=True)
-    test_case_nrs = case_stops_df[case_stops_df.values > separation_time].index.array
-    dataset_test = dataset[
-        dataset["case:concept:name"].isin(test_case_nrs)
-    ].reset_index(drop=True)
-
-    # compute targets: next event
-    def calcNextEvent(grp):
-        grp["nextEvent"] = grp[event_col].shift(periods=-1)
-        return grp
-
-    dataset_train = dataset_train.groupby("case:concept:name").apply(calcNextEvent)
-    dataset_train = dataset_train.dropna(subset=["nextEvent"]).reset_index(drop=True)
-    dataset_test = dataset_test.groupby("case:concept:name").apply(calcNextEvent)
-    dataset_test = dataset_test.dropna(subset=["nextEvent"]).reset_index(drop=True)
-
-    # convert targets into np.NAN for those prefixes in test set
-    # that end before the separation time (beginning of test set)
-    dataset_test.loc[
-        dataset_test["time:timestamp"].values < separation_time, "nextEvent"
-    ] = np.nan
-
-    # record outputs
-    if output_type == "xes":
-        log_train = converter.apply(
-            dataset_train, variant=converter.Variants.TO_EVENT_LOG
-        )
-        print("dataset_train converted to logs")
-        xes_exporter.apply(log_train, path + "/" + file_name + "_next_event_train.xes")
-        print("dataset_train exported as xes")
-        log_test = converter.apply(
-            dataset_test, variant=converter.Variants.TO_EVENT_LOG
-        )
-        print("dataset_test converted to logs")
-        xes_exporter.apply(log_test, path + "/" + file_name + "_next_event_test.xes")
-        print("dataset_test exported as xes")
-    elif output_type == "pickle":
-        dataset_train.to_pickle(path + "/" + file_name + "_next_event_train.pkl")
-        dataset_test.to_pickle(path + "/" + file_name + "_next_event_test.pkl")
-    elif output_type == "csv":
-        dataset_train.to_csv(path + "/" + file_name + "_next_event_train.pkl")
-        dataset_test.to_csv(path + "/" + file_name + "_next_event_test.pkl")
-    else:
-        print("output type unknown. Should be 'xes', 'pickle' or 'csv'")
+    

--- a/src/skpm/event_logs/split.py
+++ b/src/skpm/event_logs/split.py
@@ -82,7 +82,7 @@ def unbiased(
     >>> from skpm.event_logs import BPI12
     >>> from skpm.event_logs import split
     >>> bpi12 = BPI12()
-    >>> df_train, df_test = split.unbiased(bpi12.log **bpi12.unbiased_split_params)
+    >>> df_train, df_test = split.unbiased(bpi12.log, **bpi12.unbiased_split_params)
     >>> df_train.shape, df_test.shape
     ((117546, 7), (55952, 7))
 

--- a/src/skpm/event_logs/split.py
+++ b/src/skpm/event_logs/split.py
@@ -1,136 +1,122 @@
 import pandas as pd
-import numpy as np
-from skpm.event_logs import read_xes
+from skpm.config import EventLogConfig as elc
 
 
-def start_from_date(dataset, start_date):
-    """
-    removes outliers starting before start date from dataset
-    Args:
-        dataset: pandas DataFrame
-        start_date: string "MM-YYYY": dataset starts here after removing outliers
-
-    Returns:
-        dataset: pandas Dataframe
-
-    """
-    case_starts_df = pd.DataFrame(
-        dataset.groupby("case:concept:name")["time:timestamp"].min().reset_index()
+def _bounded_dataset(dataset: pd.DataFrame, start_date, end_date: int) -> pd.DataFrame:
+    grouped = dataset.groupby(elc.case_id, as_index=False)[elc.timestamp].agg(
+        ["min", "max"]
     )
-    case_starts_df["date"] = case_starts_df["time:timestamp"].dt.to_period("M")
-    cases_after = case_starts_df[case_starts_df["date"].astype("str") >= pd.Period(start_date)][
-        "case:concept:name"
-    ].values
-    dataset = dataset[dataset["case:concept:name"].isin(cases_after)]
+
+    start_date = (
+        pd.Period(start_date)
+        if start_date
+        else dataset[elc.timestamp].min().to_period("M")
+    )
+    end_date = (
+        pd.Period(end_date) if end_date else dataset[elc.timestamp].max().to_period("M")
+    )
+    bounded_cases = grouped[
+        (grouped["min"].dt.to_period("M") >= start_date)
+        & (grouped["max"].dt.to_period("M") <= end_date)
+    ][elc.case_id].values
+    dataset = dataset[dataset[elc.case_id].isin(bounded_cases)]
     return dataset
 
 
-def end_before_date(dataset, end_date):
-    """
-
-    removes outliers ending after end date from dataset
-    Args:
-        dataset: pandas DataFrame
-        end_date: string "MM-YYYY": dataset stops here after removing outliers
-
-    Returns:
-        dataset: pandas Dataframe
-    """
-    case_stops_df = pd.DataFrame(
-        dataset.groupby("case:concept:name")["time:timestamp"].max().reset_index()
+def _unbiased(dataset: pd.DataFrame, max_days: int) -> pd.DataFrame:
+    grouped = (
+        dataset.groupby(elc.case_id, as_index=False)[elc.timestamp]
+        .agg(["min", "max"])
+        .assign(
+            duration=lambda x: (x["max"] - x["min"]).dt.total_seconds() / (24 * 60 * 60)
+        )
     )
-    case_stops_df["date"] = case_stops_df["time:timestamp"].dt.to_period("M")
-    cases_before = case_stops_df[case_stops_df["date"] <= pd.Period(end_date)][
-        "case:concept:name"
-    ].values
-    dataset = dataset[dataset["case:concept:name"].isin(cases_before)]
-    return dataset
 
-
-def limited_duration(dataset, max_duration):
-    """
-
-    limits dataset to cases shorter than maximal duration and debiases the end of the dataset
-    by dropping cases starting after the last timestamp of the dataset - max_duration
-    Args:
-        dataset: pandas DataFrame
-        max_duration: float
-
-    Returns:
-        dataset: pandas Dataframe
-        latest_start: timeStamp with new end time for the dataset
-
-    """
-    # compute each case's duration
-    agg_dict = {"time:timestamp": ["min", "max"]}
-    duration_df = pd.DataFrame(
-        dataset.groupby("case:concept:name").agg(agg_dict)
-    ).reset_index()
-    duration_df["duration"] = (
-        duration_df[("time:timestamp", "max")] - duration_df[("time:timestamp", "min")]
-    ).dt.total_seconds() / (24 * 60 * 60)
     # condition 1: cases are shorter than max_duration
-    condition_1 = duration_df["duration"] <= max_duration * 1.00000000001
-    cases_retained = duration_df[condition_1]["case:concept:name"].values
-    dataset = dataset[dataset["case:concept:name"].isin(cases_retained)].reset_index(
-        drop=True
-    )
+    condition_1 = grouped["duration"] <= max_days * 1.00000000001
     # condition 2: drop cases starting after the dataset's last timestamp - the max_duration
-    latest_start = dataset["time:timestamp"].max() - pd.Timedelta(
-        max_duration, unit="D"
-    )
-    condition_2 = duration_df[("time:timestamp", "min")] <= latest_start
-    cases_retained = duration_df[condition_2]["case:concept:name"].values
-    dataset = dataset[dataset["case:concept:name"].isin(cases_retained)].reset_index(
-        drop=True
-    )
-    return dataset, latest_start
+    latest_start = dataset[elc.timestamp].max() - pd.Timedelta(max_days, unit="D")
+    condition_2 = grouped["min"] <= latest_start
+
+    unbiased_cases = grouped[condition_1 & condition_2][elc.case_id].values
+    dataset = dataset[dataset[elc.case_id].isin(unbiased_cases)]
+    return dataset
 
 
-def trainTestSplit(dataset, test_len, start_date,end_date, max_days):
+def unbiased(
+    dataset: pd.DataFrame,
+    start_date: str | pd.Period | None,
+    end_date: str | pd.Period | None,
+    max_days: int,
+    test_len: float = 0.2,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
     """
-    splits the dataset in train and test set, applying strict temporal splitting and
-    debiasing the test set
-    Args:
-        df: pandas DataFrame
-        test_len: float: share of cases belonging in test set
-        latest_start: timeStamp with new end time for the dataset
-    Returns:
-        df_train: pandas DataFrame
-        df_test: pandas DataFrame
-    """
-    dataset["time:timestamp"] = pd.to_datetime(dataset["time:timestamp"], utc=True)
+    Unbiased split of event log into training and test set [1].
 
-    if start_date:
-        dataset = start_from_date(dataset, start_date)
-    if end_date:
-        dataset = end_before_date(dataset, end_date)
-    
-    dataset.drop_duplicates(inplace=True)
-    dataset, latest_start = limited_duration(dataset, max_days)
-    
+    Code adapted from [2].
+
+    Parameters
+    ----------
+    dataset: pd.DataFrame
+        Event log.
+
+    start_date: str
+        Start date of the event log.
+
+    end_date: str
+        End date of the event log.
+
+    max_days: int
+        Maximum duration of cases.
+
+    test_len: float, default=0.2
+        Proportion of cases to be used for the test set.
+
+    Returns
+    -------
+    - df_train: pd.DataFrame, training set
+    - df_test: pd.DataFrame, test set
+
+    Example
+    -------
+    >>> from skpm.event_logs import BPI12
+    >>> from skpm.event_logs import split
+    >>> bpi12 = BPI12()
+    >>> df_train, df_test = split.unbiased(bpi12.log **bpi12.unbiased_split_params)
+    >>> df_train.shape, df_test.shape
+    ((117546, 7), (55952, 7))
+
+    References:
+    ----------
+    [1] Hans Weytjens, Jochen De Weerdt. Creating Unbiased Public Benchmark Datasets with Data Leakage Prevention for Predictive Process Monitoring, 2021. doi: 10.1007/978-3-030-94343-1_2
+    [2] https://github.com/hansweytjens/predictive-process-monitoring-benchmarks
+    """
+    dataset[elc.timestamp] = pd.to_datetime(
+        dataset[elc.timestamp], utc=True
+    ).dt.tz_localize(None)
+
+    # bounding the event log
+    if start_date or end_date:
+        dataset = _bounded_dataset(dataset, start_date, end_date)
+
+    # drop longest cases and debiasing end of dataset
+    dataset = _unbiased(dataset, max_days)
+
     # preliminaries
-    case_starts_df = dataset.groupby("case:concept:name")["time:timestamp"].min()
-    case_nr_list_start = case_starts_df.sort_values().index.array
-    case_stops_df = dataset.groupby("case:concept:name")["time:timestamp"].max().to_frame()
+    grouped = dataset.groupby(elc.case_id, as_index=False)[elc.timestamp].agg(
+        ["min", "max"]
+    )
 
     ### TEST SET ###
-    first_test_case_nr = int(len(case_nr_list_start) * (1 - test_len))
-    first_test_start_time = np.sort(case_starts_df.values)[first_test_case_nr]
+    first_test_case_nr = int(len(grouped) * (1 - test_len))
+    first_test_start_time = grouped["min"].sort_values().values[first_test_case_nr]
     # retain cases that end after first_test_start time
-    test_case_nrs = case_stops_df[
-        case_stops_df["time:timestamp"].values >= first_test_start_time
-    ].index.array
-    df_test_all = dataset[dataset["case:concept:name"].isin(test_case_nrs)].reset_index(drop=True)
-
-    # drop prefixes in test set that are past latest_start
-    df_test = df_test_all[df_test_all["time:timestamp"] <= latest_start]
+    test_case_nrs = grouped.loc[
+        grouped["max"].values >= first_test_start_time, elc.case_id
+    ]
+    df_test = dataset[dataset[elc.case_id].isin(test_case_nrs)].reset_index(drop=True)
 
     #### TRAINING SET ###
-    train_case_nrs = case_stops_df[
-        case_stops_df["time:timestamp"].values < first_test_start_time
-    ].index.array  # added values
-    df_train = dataset[dataset["case:concept:name"].isin(train_case_nrs)].reset_index(drop=True)
+    df_train = dataset[~dataset[elc.case_id].isin(test_case_nrs)].reset_index(drop=True)
 
     return df_train, df_test
-    

--- a/tests/event_logs/test_bpi.py
+++ b/tests/event_logs/test_bpi.py
@@ -1,17 +1,63 @@
 import os
 import pytest
 import pandas as pd
-from skpm.event_logs import BPI20, BPI13ClosedProblems, BPI19
+from skpm.event_logs import BPI13ClosedProblems, BPI19
+
+"""Shapes to validate the logs:"""
+# BPI12
+# (262200, 7)
+# (117546, 7) (55952, 7)
+# ========================================
+# BPI13ClosedProblems
+# (6660, 12)
+# Unbiased split parameters not supported.
+# ========================================
+# BPI13Incidents
+# (65533, 12)
+# Unbiased split parameters not supported.
+# ========================================
+# BPI13OpenProblems
+# (2351, 11)
+# Unbiased split parameters not supported.
+# ========================================
+# BPI17
+# (1202267, 19)
+# (805809, 19) (294882, 19)
+# ========================================
+# BPI19
+# (1595923, 21)
+# (538293, 21) (538880, 21)
+# ========================================
+# BPI20PrepaidTravelCosts
+# (18246, 22)
+# (10809, 22) (4928, 22)
+# ========================================
+# BPI20TravelPermitData
+# (86581, 173)
+# (51878, 173) (32390, 173)
+# ========================================
+# BPI20RequestForPayment
+# (36796, 14)
+# (23295, 14) (7053, 14)
+# ========================================
+# BPI20DomesticDeclarations
+# (56437, 10)
+# Unbiased split parameters not supported.
+# ========================================
+# BPI20InternationalDeclarations
+# (72151, 23)
+# Unbiased split parameters not supported.
+# ========================================
+# Sepsis
+# (15214, 32)
+# Unbiased split parameters not supported.
+# ========================================
 
 
 @pytest.mark.timeout(300)
 def test_bpi():
     # TODO: deactivate warnings from pm4py
     # TODO: the download is fast but the reading (pm4py) is slow
-
-    # not implemented modules
-    with pytest.raises(Exception) as exc_info:
-        log = BPI20()
 
     # testing BPI13ClosedProblems (smallest log, faster to test)
     default_path = "data/BPI13ClosedProblems/BPI_Challenge_2013_closed_problems.parquet"
@@ -36,3 +82,33 @@ def test_bpi():
     shutil.rmtree("data/BPI13ClosedProblems")
     if os.path.dirname(bpi19.file_path) != os.getcwd():
         shutil.rmtree(os.path.dirname(bpi19.file_path))
+
+# from skpm.event_logs import *
+# from skpm.event_logs import split
+
+# datasets = [
+#     BPI12,
+#     BPI13ClosedProblems,
+#     BPI13Incidents,
+#     BPI13OpenProblems,
+#     BPI17,
+#     BPI19,
+#     BPI20PrepaidTravelCosts,
+#     BPI20TravelPermitData,
+#     BPI20RequestForPayment,
+#     BPI20DomesticDeclarations,
+#     BPI20InternationalDeclarations,
+#     Sepsis,
+# ]
+
+# for d in datasets:
+#     print(d.__name__)
+#     log = d()
+#     print(log.log.shape)
+#     try:
+#         train, test = split.unbiased(log.log, **log.unbiased_split_params)
+#         print(train.shape, test.shape)
+#     except Exception as e:
+#         print(e)
+        
+#     print("=="*20)


### PR DESCRIPTION
**Summary**

Unbiased split of event logs, adapted from [here](https://github.com/hansweytjens/predictive-process-monitoring-benchmarks/blob/main/create_benchmarks.py).

**Notes**

- tests are missing
- documentation of BPI logs is completely wrong 
- only the split for full traces was considered, not for prefixes