### PR TITLE
feat: global event log config mixin

### DIFF
--- a/src/skpm/base.py
+++ b/src/skpm/base.py
@@ -3,20 +3,19 @@ from pandas import DataFrame
 from sklearn.base import BaseEstimator
 from sklearn.utils.validation import validate_data
 
-from .config import EventLogConfig as elc
+from skpm.config import EventLogConfigMixin
+
 from .utils.validation import ensure_list, validate_columns
 
 
-class BaseProcessEstimator(BaseEstimator):
-    """Base class for all process estimators in skpm.
+class BaseProcessEstimator(BaseEstimator, EventLogConfigMixin):
+    """Base class for all process estimators in SkPM.
 
     This class implements a common interface for all process,
     aiming at standardizing the validation and transformation
     of event logs.
 
-    For instance, all event logs must have a `case_id` column.
     """
-
     def _validate_log(
         self,
         X: DataFrame,
@@ -99,6 +98,6 @@ class BaseProcessEstimator(BaseEstimator):
             True if the case ID column is found, False otherwise.
         """
         for col in columns:
-            if col.endswith(elc.case_id):
+            if col.endswith(self.case_id):
                 return col
         raise ValueError(f"Case ID column not found.")

--- a/src/skpm/config.py
+++ b/src/skpm/config.py
@@ -1,18 +1,181 @@
-from dataclasses import dataclass
+from typing import Dict, Optional
 
-EndOfTrace = str
+class _EventLogConfig:
+    """
+    Global configuration manager for event log column mappings and file formats.
 
-@dataclass
-class EventLogConfig:
-    case_id: str = "case:concept:name"
-    activity: str = "concept:name"
-    resource: str = "org:resource"
-    timestamp: str = "time:timestamp"
-
-    default_file_format: str = ".parquet"
+    This class supports global configuration following the classic XES naming.
+    Changes to the global config  automatically propagate to all instances.
+    SkPM will never rename columns, so users should ensure their data matches the
+    expected column names.
     
-    EOT: EndOfTrace = "EOT"
+    Attributes
+    ----------
+    case_id : str
+        Case ID column name.
+    activity : str
+        Activity column name.
+    timestamp : str
+        Timestamp column name.
+    resource : str
+        Resource column name (optional, not used in this class but can be added).
 
-    def update(self, **kwargs):
-        for key, value in kwargs.items():
-            setattr(self, key, value)
+    Methods
+    -------
+    to_dict() -> Dict[str, str]
+        Convert current configuration to dictionary.
+    get_global_config() -> Dict[str, str]
+        Get the current global configuration.
+    set_global_config(case_id: Optional[str] = None, activity: Optional[str] = None, timestamp: Optional[str] = None) -> None
+        Set the global configuration.
+    reset_global_config() -> None
+        Reset global configuration to defaults.
+
+    Examples
+    --------
+    # Set global configuration
+    EventLogConfig.set_global_config(case_id='case_id', activity='activity')
+
+    # Reset global configuration to defaults
+    EventLogConfig.reset_global_config()
+    
+    Notes
+    -----
+    The global configuration is shared across all instances of EventLogConfig.
+    If you need instance-specific configurations, consider subclassing EventLogConfig.
+    This class is designed to be used as a singleton, where the global configuration
+    is modified through class methods rather than instance methods.
+    """
+
+    # Global default configuration - shared across all instances
+    _GLOBAL_CONFIG = {
+        "case_id": "case:concept:name",
+        "activity": "concept:name",
+        "timestamp": "time:timestamp",
+        "resource": "org:resource",  # should be optional
+        "EOT": "<EOT>",  # End of trace marker
+    }
+    _instance = None
+
+    def __new__(cls):
+        """Ensure only one instance of EventLogConfig exists."""
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    @property
+    def case_id(self) -> str:
+        """Case ID column name."""
+        return self._GLOBAL_CONFIG["case_id"]
+
+    @property
+    def activity(self) -> str:
+        """Activity column name."""
+        return self._GLOBAL_CONFIG["activity"]
+
+    @property
+    def timestamp(self) -> str:
+        """Timestamp column name."""
+        return self._GLOBAL_CONFIG["timestamp"]
+    
+    @property
+    def resource(self) -> str:
+        """Resource column name."""
+        return self._GLOBAL_CONFIG["resource"]
+    
+    @property
+    def EOT(self) -> str:
+        """End of trace marker."""
+        return self._GLOBAL_CONFIG["EOT"]
+
+    def to_dict(self) -> Dict[str, str]:
+        """Convert current configuration to dictionary."""
+        return {
+            "case_id": self.case_id,
+            "activity": self.activity,
+            "timestamp": self.timestamp,
+            "resource": self.resource,
+            "EOT": self.EOT,
+        }
+
+    @classmethod
+    def get_global_config(cls) -> Dict[str, str]:
+        """Get the current global configuration."""
+        return cls._GLOBAL_CONFIG.copy()
+
+    @classmethod
+    def set_global_config(
+        cls,
+        case_id: Optional[str] = None,
+        activity: Optional[str] = None,
+        timestamp: Optional[str] = None,
+        resource: Optional[str] = None,
+        EOT: Optional[str] = None,
+    ) -> None:
+        """Set the global configuration."""
+        if case_id is not None:
+            cls._GLOBAL_CONFIG["case_id"] = case_id
+        if activity is not None:
+            cls._GLOBAL_CONFIG["activity"] = activity
+        if timestamp is not None:
+            cls._GLOBAL_CONFIG["timestamp"] = timestamp
+        if resource is not None:
+            cls._GLOBAL_CONFIG["resource"] = resource
+        if EOT is not None:
+            cls._GLOBAL_CONFIG["EOT"] = EOT
+
+    @classmethod
+    def reset_global_config(cls) -> None:
+        """Reset global configuration to defaults."""
+        cls._GLOBAL_CONFIG = {
+            "case_id": "case:concept:name",
+            "activity": "concept:name",
+            "timestamp": "time:timestamp",
+            "resource": "org:resource",
+            "EOT": "<EOT>",
+        }
+
+    def __repr__(self) -> str:
+        """String representation showing current configuration."""
+        config = self.to_dict()
+
+        lines = ["EventLogConfig("]
+        for key, value in config.items():
+            lines.append(f"  {key}='{value}'")
+
+        return "\n".join(lines) + "\n)"
+
+EventLogConfig: _EventLogConfig = _EventLogConfig()
+
+class EventLogConfigMixin:
+    """Mixin class to provide event log configuration properties.
+    
+    This mixin will be used globally across SkPM to ensure that
+    all event log handling classes have access to the same
+    configuration properties for case ID, activity, and timestamp.
+    
+    *Note*: SkPM will never rename columns, so users should ensure their data matches the
+    expected column names.
+    Attributes
+    ----------
+    case_id : str
+        Case ID column name.
+    activity : str
+        Activity column name.
+    timestamp : str
+        Timestamp column name.
+    """
+
+    _config: _EventLogConfig = _EventLogConfig()
+
+    @property
+    def case_id(self) -> str:
+        return self._config.case_id
+
+    @property
+    def activity(self) -> str:
+        return self._config.activity
+
+    @property
+    def timestamp(self) -> str:
+        return self._config.timestamp

--- a/src/skpm/feature_extraction/case/time.py
+++ b/src/skpm/feature_extraction/case/time.py
@@ -1,6 +1,6 @@
-from skpm.config import EventLogConfig as elc
+from skpm.config import EventLogConfigMixin
 
-class TimestampCaseLevel:
+class TimestampCaseLevel(EventLogConfigMixin):
     """
     Extracts time-related features at the case level.
 
@@ -22,11 +22,11 @@ class TimestampCaseLevel:
     def accumulated_time(cls, case, ix_list, time_unit="s"):
         """Calculate the accumulated time from the start of each case in seconds."""
         return (
-            case[elc.timestamp]
+            case[cls().timestamp]
             .apply(lambda x: x - x.min())
             .loc[ix_list]
             .dt.total_seconds()
-            / cls.TIME_UNIT_MULTIPLIER.get(time_unit, 1)
+            / cls().TIME_UNIT_MULTIPLIER.get(time_unit, 1)
         )
 
     @classmethod
@@ -36,13 +36,13 @@ class TimestampCaseLevel:
         **NOTE**: This should be used as a target feature, since the _next_ step is 
         needed to calculate the execution time of each event."""
         return (
-            case[elc.timestamp]
+            case[cls().timestamp]
             .diff(-1)
             .dt.total_seconds()
             .fillna(0)
             .loc[ix_list]
             .abs() # to avoid negative numbers caused by diff-1
-            / cls.TIME_UNIT_MULTIPLIER.get(time_unit, 1)
+            / cls().TIME_UNIT_MULTIPLIER.get(time_unit, 1)
         )
 
     @classmethod
@@ -53,9 +53,9 @@ class TimestampCaseLevel:
         is needed to calculate the remaining time of each event."""
         
         return (
-            case[elc.timestamp]
+            case[cls().timestamp]
             .apply(lambda x: x.max() - x)
             .loc[ix_list]
             .dt.total_seconds()
-            / cls.TIME_UNIT_MULTIPLIER.get(time_unit, 1)
+            / cls().TIME_UNIT_MULTIPLIER.get(time_unit, 1)
         )

--- a/src/skpm/feature_extraction/event/time.py
+++ b/src/skpm/feature_extraction/event/time.py
@@ -1,5 +1,3 @@
-from skpm.config import EventLogConfig as elc
-
 class TimestampEventLevel:
     """
     Provides methods to extract time-related features from the event level.

--- a/src/skpm/sequence_encoding/aggregation.py
+++ b/src/skpm/sequence_encoding/aggregation.py
@@ -7,7 +7,6 @@ from sklearn.utils._param_validation import StrOptions
 from sklearn.utils.validation import check_is_fitted
 
 from skpm.base import BaseProcessEstimator
-from skpm.config import EventLogConfig as elc
 
 def handle_aggregation_method(method):
     """Handle the aggregation method.
@@ -80,7 +79,6 @@ class Aggregation(OneToOneFeatureMixin, TransformerMixin, BaseProcessEstimator):
     >>> Aggregation().fit_transform(df)
     """
 
-    _case_id = elc.case_id
     _parameter_constraints = {
         "method": [
             StrOptions({"sum", "mean", "median", "norm"}),
@@ -177,7 +175,7 @@ class Aggregation(OneToOneFeatureMixin, TransformerMixin, BaseProcessEstimator):
 
     def _transform_pandas(self, X: pd.DataFrame):
         """Transforms Pandas DataFrame."""
-        group = X.groupby(self._case_id)
+        group = X.groupby(self.case_id)
 
         X = (
             group.rolling(window=self.prefix_len, min_periods=1)
@@ -205,9 +203,9 @@ class Aggregation(OneToOneFeatureMixin, TransformerMixin, BaseProcessEstimator):
                 )
 
         X = X.with_columns([
-            _make_rolling_expr(c, self._method_fn).over(self._case_id)
+            _make_rolling_expr(c, self._method_fn).over(self.case_id)
             for c in X.columns
-            if c != self._case_id
+            if c != self.case_id
         ])
  
-        return X.drop(self._case_id)
+        return X.drop(self.case_id)

--- a/src/skpm/utils/validation.py
+++ b/src/skpm/utils/validation.py
@@ -3,7 +3,7 @@ from typing import Iterable, Union, Any
 
 
 def validate_methods_from_class(
-    class_obj: Any, methods: Union[str, list[str]] = "all"
+    class_obj: object, methods: Union[str, list[str]] = "all"
 ) -> list[tuple[str, callable]]:
     """Validate methods from a class.
 


### PR DESCRIPTION
Introducing a new way of globally handling event log columns' names.

- `skpm.config.EventLogConfig` is a Singleton object to globally retrieve, update, and reset column names (e.g., `case_id = "case:concept:name"`)
- Use the object above to change the global state, e.g., `EventLog.set_global_config(case_id="case_id")`.
- `skpm.config.EventLogConfigMixing` is also introduced, and it should be inherited by any class that must access event logs' columns (e.g., `self.case_id`)

Limitations:
- not thread-safe
- no context manager